### PR TITLE
Do not translate `Extended Help`

### DIFF
--- a/src/openai.jl
+++ b/src/openai.jl
@@ -22,7 +22,7 @@ Please note:
 - Skip changing words in the form of `[xxx](@ref)` or `[xxx](@ref yyy)`.
 - Do not change any URL.
 - If $(lang) indicates English (e.g., "en"), return the input unchanged.
-
+- Skip translation `Extended Help` since it has a special meaning in Julia
 Return only the resulting text.
 """
 end


### PR DESCRIPTION
In Julia, `Extended Help` has a special meaning in Julia's help mode. We want to skip the translation of this header.

https://docs.julialang.org/en/v1/stdlib/REPL/#Help-mode